### PR TITLE
Fix not requiring ssl mail when ssl disabled

### DIFF
--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -6,10 +6,19 @@
       You need to define a required configuration setting (`{{ item }}`) for using this role.
   when: "vars[item] == ''"
   with_items:
-    - devture_traefik_ssl_email_address
     - devture_traefik_uid
     - devture_traefik_gid
     - devture_traefik_entrypoint_primary
+
+- name: Fail if required Traefik settings for SSL are not defined
+  ansible.builtin.fail:
+    msg: >-
+      You need to define a required configuration setting (`{{ item }}`) for using this role with SSL enabled.
+  when:
+    - devture_traefik_config_entrypoint_web_secure_enabled
+    - "vars[item] == ''"
+  with_items:
+    - devture_traefik_ssl_email_address
 
 - name: Fail if required Traefik Dashboard settings not defined
   ansible.builtin.fail:

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -45,6 +45,7 @@ entryPoints:
   {{ additional_entrypoint.name }}: {{ additional_entrypoint_config | to_json }}
 {% endfor %}
 
+{% if devture_traefik_config_entrypoint_web_secure_enabled %}
 certificatesResolvers:
   default:
     acme:
@@ -53,6 +54,7 @@ certificatesResolvers:
       caServer: {{ devture_traefik_config_letsencrypt_resolver_caServer | to_json }}
       httpChallenge:
         entrypoint: {{ devture_traefik_config_letsencrypt_httpChallenge_entrypoint | to_json }}
+{% endif %}
 
 providers:
   docker:


### PR DESCRIPTION
Fix #2 

Verified that:
- [x] role ignores missing mail if web-secure endpoint is disabled
- [x] role still checks for missing mail if web-secure stays enabled as default
- [x] role still can successfully deploy traefik container when ssl is disabled
- [x] traefik container launches and is configured as expected when ssl is disabled

Other points:
- I thought it could be that some users may disable the preconfigured web-secure endpoint from this role but still want the acme part of the config being added (which I exclude with this PR if web-secure is disabled to ensure traefik does not try to setup anything ssl related). Maybe another variable (like `disable_ssl_config`) should be introduced, I have restrained from doing this for the first draft without further discussion.