### PR TITLE
Add additional files in config folder

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -233,3 +233,13 @@ devture_traefik_environment_variables: ''
 #   my.label=1
 #   another.label="here"
 devture_traefik_labels_additional_labels: ''
+
+# devture_traefik_additional_config_files_content can be used to add addtional files to the traefik config dir
+# This makes it possible to add private key files for using the DNS challenge
+# Example:
+#devture_traefik_additional_config_files_content: 
+#  - name: 'privatekey.key'
+#    content: 'here the long private key content'
+#  - name: 'otherfile'
+#    content: 'other file content'
+devture_traefik_additional_config_files_content: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -46,6 +46,18 @@
       become: false
       delegate_to: 127.0.0.1
 
+- name: Ensure Traefik additional files installed
+  when: devture_traefik_additional_config_files_content != [] | bool
+  ansible.builtin.copy:
+    content: "{{ item.content }}"
+    dest: "{{ devture_traefik_config_dir_path }}/{{ item.name }}"
+    owner: "{{ devture_traefik_uid }}"
+    group: "{{ devture_traefik_gid }}"
+    mode: 0640
+  loop: "{{ devture_traefik_additional_config_files_content }}"
+  loop_control:
+    label: "{{ item.name }}"
+
 - name: Ensure Traefik environment variables installed
   ansible.builtin.copy:
     content: "{{ devture_traefik_environment_variables }}"


### PR DESCRIPTION
When using DNS challenge for AMCE it's sometime necessary to add a private key file (for example: TransIP needs an private key file with `TRANSIP_PRIVATE_KEY_PATH `in the enviroment variables). `devture_traefik_additional_config_files_content` provides a way to add this file without copying it to the server manually.

