### PR TITLE
Add easy exposure of metrics

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,9 +46,10 @@ devture_traefik_config_log_level: INFO
 # Controls whether logs for incoming requests are collected
 devture_traefik_config_accessLog_enabled: true
 
-# Controls whether prometheus metrics will be exposed. You will need to set
-# a entrypoint named `metrics` for this to work properly
+# Controls whether Prometheus metrics will be exposed on a new metrics entrypoint.
+# See devture_traefik_config_entrypoint_metrics_enabled
 devture_traefik_config_metrics_prometheus_enabled: false
+devture_traefik_config_metrics_prometheus_entrypoint: metrics
 
 # Controls whether the ACME (https://en.wikipedia.org/wiki/Automatic_Certificate_Management_Environment) certificate resolver is enabled.
 # By default, if the web-secure entrypoint is enabled, we enable Let's Encrypt.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,10 @@ devture_traefik_config_log_level: INFO
 # Controls whether logs for incoming requests are collected
 devture_traefik_config_accessLog_enabled: true
 
+# Controls whether prometheus metrics will be exposed. You will need to set
+# a entrypoint named `metrics` for this to work properly
+devture_traefik_config_metrics_prometheus_enabled: false
+
 # Controls whether the ACME (https://en.wikipedia.org/wiki/Automatic_Certificate_Management_Environment) certificate resolver is enabled.
 # By default, if the web-secure entrypoint is enabled, we enable Let's Encrypt.
 devture_traefik_config_certificatesResolvers_acme_enabled: "{{ devture_traefik_config_entrypoint_web_secure_enabled }}"
@@ -92,6 +96,21 @@ devture_traefik_config_entrypoint_web_secure_forwardedHeaders_trustedIPs: []
 # Controls `forwardedHeaders.insecure` for this entrypoint.
 # Also see: `devture_traefik_config_entrypoint_web_secure_forwardedHeaders_trustedIPs`
 devture_traefik_config_entrypoint_web_secure_forwardedHeaders_insecure: false
+
+# Controls whether the metrics entrypoint is enabled
+devture_traefik_config_entrypoint_metrics_enabled: "{{ devture_traefik_config_metrics_prometheus_enabled }}"
+devture_traefik_config_entrypoint_metrics_name: metrics
+devture_traefik_config_entrypoint_metrics_port: 8082
+devture_traefik_config_entrypoint_metrics_port_in_container: 8082
+devture_traefik_config_entrypoint_metrics_address: ":{{ devture_traefik_config_entrypoint_metrics_port_in_container }}"
+# Controls `forwardedHeaders.trustedIPs`, specifying from which IPs to trust `X-Forwarded-*` headers.
+# By default, we expect that there's no other reverse-proxy in front of us, so we don't trust anything.
+# Also see: `devture_traefik_config_entrypoint_metrics_forwardedHeaders_insecure`
+devture_traefik_config_entrypoint_metrics_forwardedHeaders_trustedIPs: []
+# Controls `forwardedHeaders.insecure` for this entrypoint.
+# Also see: `devture_traefik_config_entrypoint_metrics_forwardedHeaders_trustedIPs`
+devture_traefik_config_entrypoint_metrics_forwardedHeaders_insecure: false
+
 
 # Controls the `providers.docker.network` configuration option.
 devture_traefik_config_providers_docker_network: "{{ devture_traefik_container_network }}"
@@ -189,6 +208,11 @@ devture_traefik_container_web_host_bind_port: "{{ devture_traefik_config_entrypo
 #
 # Takes an "<ip>:<port>" value (e.g. "127.0.0.1:443"), just a port number or an empty string to not expose.
 devture_traefik_container_web_secure_host_bind_port: "{{ devture_traefik_config_entrypoint_web_secure_port if devture_traefik_config_entrypoint_web_secure_enabled else '' }}"
+
+# Specifies how the container publishes its metrics port
+#
+# Takes an "<ip>:<port>" value (e.g. "127.0.0.1:8082"), just a port number or an empty string to not expose.
+devture_traefik_container_metrics_host_bind_port: "{{ devture_traefik_config_entrypoint_metrics_port if devture_traefik_config_entrypoint_metrics_enabled else '' }}"
 
 # Default Traefik configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,7 +100,7 @@ devture_traefik_config_entrypoint_web_secure_forwardedHeaders_insecure: false
 
 # Controls whether the metrics entrypoint is enabled
 devture_traefik_config_entrypoint_metrics_enabled: "{{ devture_traefik_config_metrics_prometheus_enabled }}"
-devture_traefik_config_entrypoint_metrics_name: metrics
+devture_traefik_config_entrypoint_metrics_name: "{{ devture_traefik_config_metrics_prometheus_entrypoint }}"
 devture_traefik_config_entrypoint_metrics_port: 8082
 devture_traefik_config_entrypoint_metrics_port_in_container: 8082
 devture_traefik_config_entrypoint_metrics_address: ":{{ devture_traefik_config_entrypoint_metrics_port_in_container }}"

--- a/templates/devture-traefik.service.j2
+++ b/templates/devture-traefik.service.j2
@@ -37,6 +37,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% if devture_traefik_container_web_secure_host_bind_port %}
 			-p {{ devture_traefik_container_web_secure_host_bind_port }}:{{ devture_traefik_config_entrypoint_web_secure_port_in_container }} \
 			{% endif %}
+			{% if devture_traefik_container_metrics_host_bind_port %}
+			-p {{ devture_traefik_container_metrics_host_bind_port }}:{{ devture_traefik_config_entrypoint_metrics_port_in_container }} \
+			{% endif %}
 			{% for additional_entrypoint in devture_traefik_additional_entrypoints %}
 			-p {{ additional_entrypoint.host_bind_port }}:{{ additional_entrypoint.port }} \
 			{% endfor %}

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -97,7 +97,7 @@ certificatesResolvers:
 {% if devture_traefik_config_metrics_prometheus_enabled %}
 metrics:
   prometheus:
-    entryPoint: metrics
+    entryPoint: {{ devture_traefik_config_metrics_prometheus_entrypoint | to_json }}
 {% endif %}
 
 providers:

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -58,6 +58,21 @@ entryPoints:
     {% endif %}
 {% endif %}
 
+{% if devture_traefik_config_entrypoint_metrics_enabled %}
+  {{ devture_traefik_config_entrypoint_metrics_name }}:
+    address: {{ devture_traefik_config_entrypoint_metrics_address | to_json }}
+
+    {% if devture_traefik_config_entrypoint_metrics_forwardedHeaders_enabled %}
+    forwardedHeaders:
+      {% if devture_traefik_config_entrypoint_metrics_forwardedHeaders_trustedIPs | length > 0 %}
+      trustedIPs: {{ devture_traefik_config_entrypoint_metrics_forwardedHeaders_trustedIPs | to_json }}
+      {% endif %}
+      {% if devture_traefik_config_entrypoint_metrics_forwardedHeaders_insecure %}
+      insecure: true
+      {% endif %}
+    {% endif %}
+{% endif %}
+
 {% for additional_entrypoint in devture_traefik_additional_entrypoints %}
   {% set additional_entrypoint_config = ({
 	  'address': ':' + (additional_entrypoint.port | string),
@@ -77,6 +92,12 @@ certificatesResolvers:
       caServer: {{ devture_traefik_config_certificatesResolvers_acme_caServer | to_json }}
       httpChallenge:
         entrypoint: {{ devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint | to_json }}
+{% endif %}
+
+{% if devture_traefik_config_metrics_prometheus_enabled %}
+metrics:
+  prometheus:
+    entryPoint: metrics
 {% endif %}
 
 providers:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,6 +10,9 @@ devture_traefik_config_entrypoint_web_forwardedHeaders_enabled: "{{ devture_trae
 # Controls whether the forwardedHeaders section appears in the configuration for the web-secure entrypoint
 devture_traefik_config_entrypoint_web_secure_forwardedHeaders_enabled: "{{ devture_traefik_config_entrypoint_web_secure_forwardedHeaders_trustedIPs | length > 0 or devture_traefik_config_entrypoint_web_secure_forwardedHeaders_insecure }}"
 
+# Controls whether the forwardedHeaders section appears in the configuration for the web-secure entrypoint
+devture_traefik_config_entrypoint_metrics_forwardedHeaders_enabled: "{{ devture_traefik_config_entrypoint_metrics_forwardedHeaders_trustedIPs | length > 0 or devture_traefik_config_entrypoint_metrics_forwardedHeaders_insecure }}"
+
 # Specifies whether the docker endpoint is a UNIX socket or not.
 # When a socket is used, we need to run the Traefik container with more privileges, so that it can read via the socket.
 devture_traefik_config_providers_docker_endpoint_is_unix_socket: "{{ devture_traefik_config_providers_docker_endpoint.startswith('unix://') }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,7 +10,7 @@ devture_traefik_config_entrypoint_web_forwardedHeaders_enabled: "{{ devture_trae
 # Controls whether the forwardedHeaders section appears in the configuration for the web-secure entrypoint
 devture_traefik_config_entrypoint_web_secure_forwardedHeaders_enabled: "{{ devture_traefik_config_entrypoint_web_secure_forwardedHeaders_trustedIPs | length > 0 or devture_traefik_config_entrypoint_web_secure_forwardedHeaders_insecure }}"
 
-# Controls whether the forwardedHeaders section appears in the configuration for the web-secure entrypoint
+# Controls whether the forwardedHeaders section appears in the configuration for the metrics entrypoint
 devture_traefik_config_entrypoint_metrics_forwardedHeaders_enabled: "{{ devture_traefik_config_entrypoint_metrics_forwardedHeaders_trustedIPs | length > 0 or devture_traefik_config_entrypoint_metrics_forwardedHeaders_insecure }}"
 
 # Specifies whether the docker endpoint is a UNIX socket or not.


### PR DESCRIPTION
This PR implements exposing metrics [the way the official documentation suggests](https://doc.traefik.io/traefik/observability/metrics/prometheus/).
It can be turned on with

```
devture_traefik_config_metrics_prometheus_enabled: true
```

This allows for very nice Grafana dashboards
![image](https://github.com/devture/com.devture.ansible.role.traefik/assets/25753802/7ece82a2-cfd6-49db-8238-94ebc3792650)
![image](https://github.com/devture/com.devture.ansible.role.traefik/assets/25753802/69c21da8-7035-4403-a652-f6cc53cb8c7b)

(yes you see a nextcloud bug there that affected a single user)


