### PR TITLE
Add support for the acme dnsChallenge

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,7 +72,7 @@ devture_traefik_config_certificatesResolvers_acme_use_staging: false
 # devture_traefik_config_certificatesResolvers_acme_caServer specifies the CA server endpoint to use.
 devture_traefik_config_certificatesResolvers_acme_caServer: "{{ 'https://acme-staging-v02.api.letsencrypt.org/directory' if devture_traefik_config_certificatesResolvers_acme_use_staging else 'https://acme-v02.api.letsencrypt.org/directory' }}"
 # devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled controls whether the Let's Encrypt httpChallenge is used or not.
-devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled: "{{ 'false' if devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled else 'true' }}"
+devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled: "{{ not devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled }}"
 # devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint controls on which entrypoint the HTTP ACME challenge is enabled.
 devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint: "{{ devture_traefik_config_entrypoint_web_name if devture_traefik_config_entrypoint_web_enabled else '' }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,8 +71,36 @@ devture_traefik_config_certificatesResolvers_acme_storage: /ssl/acme.json # in-c
 devture_traefik_config_certificatesResolvers_acme_use_staging: false
 # devture_traefik_config_certificatesResolvers_acme_caServer specifies the CA server endpoint to use.
 devture_traefik_config_certificatesResolvers_acme_caServer: "{{ 'https://acme-staging-v02.api.letsencrypt.org/directory' if devture_traefik_config_certificatesResolvers_acme_use_staging else 'https://acme-v02.api.letsencrypt.org/directory' }}"
+# devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled controls whether the Let's Encrypt httpChallenge is used or not.
+devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled: "{{ 'false' if devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled else 'true' }}"
 # devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint controls on which entrypoint the HTTP ACME challenge is enabled.
 devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint: "{{ devture_traefik_config_entrypoint_web_name if devture_traefik_config_entrypoint_web_enabled else '' }}"
+
+
+# Controls whether the ACME DNS challenge is enabled.
+# For more information on supported providers, settings and environment variables, please refer to:
+# https://doc.traefik.io/traefik/https/acme/#providers
+# If enabled, Traefik will use DNS challenges to obtain Let's Encrypt certificates.
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: false
+# Specify the DNS provider to handle DNS challenges.
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: ""
+# The delay in seconds before checking DNS propagation for the ACME DNS challenge.
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: 900
+# The list of DNS resolvers to be used for the ACME DNS challenge.
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers: []
+# Example for netcup DNS provider:
+# devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: true
+# devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: netcup
+# devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers:
+#  - "root-dns.netcup.net"
+#  - "second-dns.netcup.net"
+#
+# traefik_environment_variables_additional_variables:
+#   - "NETCUP_CUSTOMER_NUMBER='12345'"
+#   - "NETCUP_API_KEY='api_key'"
+#   - "NETCUP_API_PASSWORD='password'"
+
+
 
 # Controls whether the web entrypoint is enabled
 devture_traefik_config_entrypoint_web_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,7 @@ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: false
 # Specify the DNS provider to handle DNS challenges.
 devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: ""
 # The delay in seconds before checking DNS propagation for the ACME DNS challenge.
-devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: 900
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: '''
 # The list of DNS resolvers to be used for the ACME DNS challenge.
 devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers: []
 
@@ -92,6 +92,8 @@ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers: []
 #
 # devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: true
 # devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: netcup
+# devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: 900
+
 # devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers:
 #  - "root-dns.netcup.net"
 #  - "second-dns.netcup.net"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,7 @@ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: false
 # Specify the DNS provider to handle DNS challenges.
 devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: ""
 # The delay in seconds before checking DNS propagation for the ACME DNS challenge.
-devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: '''
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: ''
 # The list of DNS resolvers to be used for the ACME DNS challenge.
 devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,6 @@ devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled: "{{ not
 # devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint controls on which entrypoint the HTTP ACME challenge is enabled.
 devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint: "{{ devture_traefik_config_entrypoint_web_name if devture_traefik_config_entrypoint_web_enabled else '' }}"
 
-
 # Controls whether the ACME DNS challenge is enabled.
 # For more information on supported providers, settings and environment variables, please refer to:
 # https://doc.traefik.io/traefik/https/acme/#providers
@@ -88,19 +87,18 @@ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: ""
 devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: 900
 # The list of DNS resolvers to be used for the ACME DNS challenge.
 devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers: []
-# Example for netcup DNS provider:
+
+# Example for dnsChallenge and netcup DNS provider:
+#
 # devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: true
 # devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: netcup
 # devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers:
 #  - "root-dns.netcup.net"
 #  - "second-dns.netcup.net"
-#
-# traefik_environment_variables_additional_variables:
-#   - "NETCUP_CUSTOMER_NUMBER='12345'"
-#   - "NETCUP_API_KEY='api_key'"
-#   - "NETCUP_API_PASSWORD='password'"
-
-
+# traefik_environment_variables_additional_variables: |
+#   NETCUP_CUSTOMER_NUMBER=12345
+#   NETCUP_API_KEY=api_key
+#   NETCUP_API_PASSWORD=password
 
 # Controls whether the web entrypoint is enabled
 devture_traefik_config_entrypoint_web_enabled: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,9 +1,5 @@
 ---
 
-- name: Debugging
-  debug:
-    msg: "devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled is set to {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled }}"
-
 - name: Ensure Traefik paths exist
   ansible.builtin.file:
     path: "{{ item.path }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -54,13 +54,16 @@
     group: "{{ devture_traefik_gid }}"
     mode: 0640
 
-- name: Ensure Traefik labels file installed
+- name: Ensure Traefik support files installed
   ansible.builtin.template:
-    src: "{{ role_path }}/templates/labels.j2"
-    dest: "{{ devture_traefik_config_dir_path }}/labels"
+    src: "{{ role_path }}/templates/{{ item }}.j2"
+    dest: "{{ devture_traefik_config_dir_path }}/{{ item }}"
     owner: "{{ devture_traefik_uid }}"
     group: "{{ devture_traefik_gid }}"
     mode: 0640
+  with_items:
+    - env
+    - labels
 
 - name: Ensure traefik.yml installed
   ansible.builtin.copy:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Debugging
+  debug:
+    msg: "devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled is set to {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled }}"
+
 - name: Ensure Traefik paths exist
   ansible.builtin.file:
     path: "{{ item.path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,3 +18,6 @@
   block:
     - when: not devture_traefik_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/uninstall.yml"
+- name: Debugging
+  debug:
+    msg: "devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled is set to {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,3 @@
   block:
     - when: not devture_traefik_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/uninstall.yml"
-- name: Debugging
-  debug:
-    msg: "devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled is set to {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled }}"

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,0 +1,1 @@
+{{ traefik_environment_variables_additional_variables }}

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -96,7 +96,9 @@ certificatesResolvers:
       {% elif devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled %}
       dnsChallenge:
         provider: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider }}
-        delayBeforeCheck: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck }}
+        {% if devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck %}
+          delayBeforeCheck: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck }}
+        {% endif %}
         resolvers: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers }}
       {% endif %}
 {% endif %}

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -95,11 +95,11 @@ certificatesResolvers:
         entrypoint: {{ devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint | to_json }}
       {% elif devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled %}
       dnsChallenge:
-        provider: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider }}
+        provider: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider | to_json }}
         {% if devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck %}
-          delayBeforeCheck: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck }}
+          delayBeforeCheck: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck | to_json }}
         {% endif %}
-        resolvers: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers }}
+        resolvers: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers | to_json }}
       {% endif %}
 {% endif %}
 

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -93,8 +93,7 @@ certificatesResolvers:
       {% if devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled %}
       httpChallenge:
         entrypoint: {{ devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint | to_json }}
-      {% endif %}
-      {% if devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled %}
+      {% elif devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled %}
       dnsChallenge:
         provider: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider }}
         delayBeforeCheck: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck }}

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -90,8 +90,16 @@ certificatesResolvers:
       email: {{ devture_traefik_config_certificatesResolvers_acme_email | to_json }}
       storage: {{ devture_traefik_config_certificatesResolvers_acme_storage | to_json }}
       caServer: {{ devture_traefik_config_certificatesResolvers_acme_caServer | to_json }}
+      {% if devture_traefik_config_certificatesResolvers_acme_httpChallenge_enabled %}
       httpChallenge:
         entrypoint: {{ devture_traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint | to_json }}
+      {% endif %}
+      {% if devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled %}
+      dnsChallenge:
+        provider: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider }}
+        delayBeforeCheck: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck }}
+        resolvers: {{ devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers }}
+      {% endif %}
 {% endif %}
 
 {% if devture_traefik_config_metrics_prometheus_enabled %}


### PR DESCRIPTION
In this pull request, I've extended the playbook to support the dnsChallenge feature in Traefik. While I'm aware that this functionality could also be controlled via extra labels, I believe integrating it directly into our playbook could be incredibly beneficial for everyone.

One significant advantage of this approach is the added flexibility it provides. Users can now seamlessly choose between HTTP and DNS challenges for obtaining SSL certificates, tailoring the solution to their specific requirements and infrastructure setup.

Moreover, by incorporating dnsChallenge support directly into our playbook, we've ensured that sensitive information like API keys for DNS providers remains secure. Unlike embedding them directly into systemd service files, these additional variables are now stored separately and are only accessible to those with appropriate permissions (750 readability).

Possible Addition to the PR:
In the comments regarding the dnsChallenge, we could consider adding instructions on how to use the aux role to include additional files (such as a key file). However, I haven't had the chance to delve deeper into this process as it's not currently needed for my implementation  (compared to #5 )