### PR TITLE
Change dots with dashes for the router name

### DIFF
--- a/templates/provider.yml.j2
+++ b/templates/provider.yml.j2
@@ -10,7 +10,7 @@ http:
 
   routers:
     {% for domain in devture_traefik_additional_domains_to_obtain_certificates_for %}
-      {{ domain }}-dummy:
+      {{ domain|replace(".", "-") }}-dummy:
         rule: Host(`{{ domain }}`)
         service: noop@internal
         entryPoints: {{ devture_traefik_additional_domains_to_obtain_certificates_for_entryPoints | to_json }}


### PR DESCRIPTION
I think a name with dots for a router might cause problems with the docker labels at the least and in general is just not the convention, I think?