### PR TITLE
Add support for plugins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ devture_traefik_config_dir_path: "{{ devture_traefik_base_path }}/config"
 devture_traefik_ssl_dir_enabled: "{{ devture_traefik_config_certificatesResolvers_acme_enabled }}"
 devture_traefik_ssl_dir_path: "{{ devture_traefik_base_path }}/ssl"
 
+# Controls whether devture_traefik_plugins_dir_path is created and mounted
+devture_traefik_plugin_support_enabled: false
+devture_traefik_plugins_dir_path: "{{ devture_traefik_base_path }}/plugins-storage"
+
 devture_traefik_systemd_required_services_list: "{{ [devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [] }}"
 
 devture_traefik_container_image: "{{ devture_traefik_container_image_registry_prefix }}traefik:{{ devture_traefik_container_image_tag }}"
@@ -60,10 +64,6 @@ devture_traefik_config_accessLog_enabled: true
 # See devture_traefik_config_entrypoint_metrics_enabled
 devture_traefik_config_metrics_prometheus_enabled: false
 devture_traefik_config_metrics_prometheus_entrypoint: metrics
-
-# Controls whether devture_traefik_plugins_dir_path is created and mounted
-devture_traefik_plugin_support_enabled: false
-devture_traefik_plugins_dir_path: "{{ devture_traefik_base_path }}/plugins-storage"
 
 # Controls whether the ACME (https://en.wikipedia.org/wiki/Automatic_Certificate_Management_Environment) certificate resolver is enabled.
 # By default, if the web-secure entrypoint is enabled, we enable Let's Encrypt.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,10 @@ devture_traefik_config_accessLog_enabled: true
 devture_traefik_config_metrics_prometheus_enabled: false
 devture_traefik_config_metrics_prometheus_entrypoint: metrics
 
+# Controls whether devture_traefik_plugins_dir_path is created and mounted
+devture_traefik_plugin_support_enabled: false
+devture_traefik_plugins_dir_path: "{{ devture_traefik_base_path }}/plugins-storage"
+
 # Controls whether the ACME (https://en.wikipedia.org/wiki/Automatic_Certificate_Management_Environment) certificate resolver is enabled.
 # By default, if the web-secure entrypoint is enabled, we enable Let's Encrypt.
 devture_traefik_config_certificatesResolvers_acme_enabled: "{{ devture_traefik_config_entrypoint_web_secure_enabled }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,8 @@
       when: true
     - path: "{{ devture_traefik_ssl_dir_path }}"
       when: "{{ devture_traefik_ssl_dir_enabled }}"
+    - path: "{{ devture_traefik_plugins_dir_path }}"
+      when: "{{ devture_traefik_plugin_support_enabled }}"
 
 - when: devture_traefik_dashboard_basicauth_enabled | bool
   block:

--- a/templates/devture-traefik.service.j2
+++ b/templates/devture-traefik.service.j2
@@ -60,6 +60,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% if devture_traefik_config_providers_docker_endpoint_is_unix_socket %}
 			--mount type=bind,src={{ devture_traefik_config_providers_docker_endpoint | replace('unix://', '') }},dst=/var/run/docker.sock,ro \
 			{% endif %}
+			{% if devture_traefik_plugin_support_enabled %}
+			--mount type=bind,src={{ devture_traefik_plugins_dir_path }},dst=/plugins-storage,rw \
+			{% endif %}
 			{% if devture_traefik_container_extra_arguments | length > 0 %}
 			{{ devture_traefik_container_extra_arguments | join(" ") }} \
 			{% endif %}

--- a/templates/devture-traefik.service.j2
+++ b/templates/devture-traefik.service.j2
@@ -61,7 +61,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--mount type=bind,src={{ devture_traefik_config_providers_docker_endpoint | replace('unix://', '') }},dst=/var/run/docker.sock,ro \
 			{% endif %}
 			{% if devture_traefik_plugin_support_enabled %}
-			--mount type=bind,src={{ devture_traefik_plugins_dir_path }},dst=/plugins-storage,rw \
+			--mount type=bind,src={{ devture_traefik_plugins_dir_path }},dst=/plugins-storage \
 			{% endif %}
 			{% if devture_traefik_container_extra_arguments | length > 0 %}
 			{{ devture_traefik_container_extra_arguments | join(" ") }} \


### PR DESCRIPTION
Closes https://github.com/devture/com.devture.ansible.role.traefik/issues/14

Tested and verified working with the following configuration:

```
devture_traefik_plugin_support_enabled: true

devture_traefik_configuration_extension_yaml: |
  providers:
    file:
      directory: /config/
      watch: true
      filename: ""
  serversTransport:
    insecureSkipVerify: true

  experimental:
    plugins:
      geoblock:
        moduleName: "github.com/PascalMinder/geoblock"
        version: "v0.2.8"

aux_file_definitions:
  - dest: "{{ devture_traefik_config_dir_path }}/element.spatterlight.space.yml"
    content: |
      http:
        routers:
          element-router:
            rule: Host(`element.spatterlight.space`)
            service: element-service
            entryPoints:
              - web-secure
            tls:
              certResolver: default
            middlewares:
              - geoblock-middleware

        middlewares:
          geoblock-middleware:
            plugin:
              geoblock:
                silentStartUp: false
                allowLocalRequests: false
                logLocalRequests: false
                logAllowedRequests: false
                logApiRequests: false
                ignoreAPITimeout: false
                api: "https://get.geojs.io/v1/ip/country/{ip}"
                apiTimeoutMs: 750
                cacheSize: 15
                forceMonthlyUpdate: true
                allowUnknownCountries: false
                unknownCountryApiResponse: "nil"
                blackListMode: false
                addCountryHeader: false
                countries:
                  - US

        services:
          element-service:
            loadBalancer:
              servers:
                - url: "http://172.24.16.2:80"
    owner: "traefik"
    group: "traefik"
```

